### PR TITLE
Print callchains for recursive fn and use slice window

### DIFF
--- a/src/detector/lock/mod.rs
+++ b/src/detector/lock/mod.rs
@@ -363,31 +363,27 @@ fn track_callchains<'tcx>(
     callgraph: &CallGraph<'tcx>,
     tcx: TyCtxt<'tcx>,
 ) -> Vec<Vec<Vec<String>>> {
-    if source == target {
-        vec![]
-    } else {
-        let paths = callgraph.all_simple_paths(source, target);
-        paths
-            .into_iter()
-            .map(|vec| {
-                vec.iter()
-                    .zip(vec.iter().skip(1))
-                    .map(|(caller, callee)| {
-                        let caller_instance = callgraph.index_to_instance(*caller).unwrap();
-                        let caller_body = tcx.instance_mir(caller_instance.def);
-                        let callsites = callgraph.callsites(*caller, *callee).unwrap();
-                        callsites
-                            .into_iter()
-                            .map(|location| {
-                                let CallSiteLocation::FnDef(location) = location;
-                                format!("{:?}", caller_body.source_info(location).span)
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>()
-    }
+    let paths = callgraph.all_simple_paths(source, target);
+    paths
+        .into_iter()
+        .map(|vec| {
+            vec.iter()
+                .zip(vec.iter().skip(1))
+                .map(|(caller, callee)| {
+                    let caller_instance = callgraph.index_to_instance(*caller).unwrap();
+                    let caller_body = tcx.instance_mir(caller_instance.def);
+                    let callsites = callgraph.callsites(*caller, *callee).unwrap();
+                    callsites
+                        .into_iter()
+                        .map(|location| {
+                            let CallSiteLocation::FnDef(location) = location;
+                            format!("{:?}", caller_body.source_info(location).span)
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
 }
 
 // Find the diagnosis info for relation(a, b), including a's ty & span, b's ty & span, and callchains.

--- a/src/detector/lock/mod.rs
+++ b/src/detector/lock/mod.rs
@@ -367,12 +367,12 @@ fn track_callchains<'tcx>(
     paths
         .into_iter()
         .map(|vec| {
-            vec.iter()
-                .zip(vec.iter().skip(1))
-                .map(|(caller, callee)| {
-                    let caller_instance = callgraph.index_to_instance(*caller).unwrap();
+            vec.windows(2)
+                .map(|window| {
+                    let (caller, callee) = (window[0], window[1]);
+                    let caller_instance = callgraph.index_to_instance(caller).unwrap();
                     let caller_body = tcx.instance_mir(caller_instance.def);
-                    let callsites = callgraph.callsites(*caller, *callee).unwrap();
+                    let callsites = callgraph.callsites(caller, callee).unwrap();
                     callsites
                         .into_iter()
                         .map(|location| {


### PR DESCRIPTION
1. Print callchains for recursive fn
2. Use more idiomatic slice window instead of zip skip