### PR TITLE
fix: LOCKBUD_LOG is not passed from cargo-lockbud to lockbud

### DIFF
--- a/src/bin/cargo-lockbud.rs
+++ b/src/bin/cargo-lockbud.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 
 const CARGO_LOCKBUD_HELP: &str = r#"Statically detect bugs on MIR
 Usage:
-    cargo lockbud [options] [<cargo options>...] [--] [<program/test suite options>...]
+    cargo lockbud [options] [--] [<cargo build options>...]
 Common options:
     -h, --help               Print this message
     -V, --version            Print version info and exit
@@ -16,13 +16,15 @@ Common options:
     -b, --blacklist-mode     Use crate-name-list as blacklist, whitelist if not specified
     -l, --crate-name-list    Will not white-or-black list the crates if not specified.
     
-Other [options] are the same as `cargo build`. Everything after the second "--" verbatim
-to the program.
+Options after the first "--" are the same arguments that `cargo build` accepts.
+
 Examples:
     # only detect [mycrate1, mycrate2]
     cargo lockbud -k deadlock -l mycrate1,mycrate2
     # skip detecting [mycrate1, mycrate2]
     cargo lockbud -k deadlock -b -l mycrate1,mycrate2
+    # canonical command with toolchain overriden and target triple specified
+    cargo +nightly-2024-05-21 lockbud -k all -- --target riscv64gc-unknown-none-elf
 "#;
 
 fn show_help() {

--- a/src/bin/cargo-lockbud.rs
+++ b/src/bin/cargo-lockbud.rs
@@ -51,7 +51,11 @@ fn in_cargo_lockbud() {
     cmd.arg("build");
     cmd.env("RUSTC_WRAPPER", "lockbud");
     cmd.env("RUST_BACKTRACE", "full");
-    cmd.env("LOCKBUD_LOG", "info");
+
+    // Pass LOCKBUD_LOG if specified by the user. Default to info if not specified.
+    const LOCKBUD_LOG: &str = "LOCKBUD_LOG";
+    let log_level = env::var(LOCKBUD_LOG).ok();
+    cmd.env(LOCKBUD_LOG, log_level.as_deref().unwrap_or("info"));
 
     let mut args = std::env::args().skip(2);
 

--- a/src/bin/cargo-lockbud.rs
+++ b/src/bin/cargo-lockbud.rs
@@ -23,7 +23,7 @@ Examples:
     cargo lockbud -k deadlock -l mycrate1,mycrate2
     # skip detecting [mycrate1, mycrate2]
     cargo lockbud -k deadlock -b -l mycrate1,mycrate2
-    # canonical command with toolchain overriden and target triple specified
+    # canonical command with toolchain overridden and target triple specified
     cargo +nightly-2024-05-21 lockbud -k all -- --target riscv64gc-unknown-none-elf
 "#;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,7 @@ fn main() {
 fn find_sysroot() -> String {
     let home = option_env!("RUSTUP_HOME");
     let toolchain = option_env!("RUSTUP_TOOLCHAIN");
+    #[allow(clippy::option_env_unwrap)]
     match (home, toolchain) {
         (Some(home), Some(toolchain)) => format!("{}/toolchains/{}", home, toolchain),
         _ => option_env!("RUST_SYSROOT")

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,35 +56,33 @@ fn main() {
     let mut rustc_command_line_arguments = args;
     rustc_driver::install_ice_hook("ice ice ice baby", |_| ());
     let exit_code = rustc_driver::catch_with_exit_code(|| {
-        let print: String = "--print=".into();
+        let print = "--print=";
         if rustc_command_line_arguments
             .iter()
-            .any(|arg| arg.starts_with(&print))
+            .any(|arg| arg.starts_with(print))
         {
             // If a --print option is given on the command line we wont get called to analyze
             // anything. We also don't want to the caller to know that LOCKBUD adds configuration
             // parameters to the command line, lest the caller be cargo and it panics because
             // the output from --print=cfg is not what it expects.
         } else {
-            let sysroot: String = "--sysroot".into();
+            let sysroot = "--sysroot";
             if !rustc_command_line_arguments
                 .iter()
-                .any(|arg| arg.starts_with(&sysroot))
+                .any(|arg| arg.starts_with(sysroot))
             {
                 // Tell compiler where to find the std library and so on.
                 // The compiler relies on the standard rustc driver to tell it, so we have to do likewise.
-                rustc_command_line_arguments.push(sysroot);
-                rustc_command_line_arguments.push(find_sysroot());
+                rustc_command_line_arguments.push(format!("{sysroot}={}", find_sysroot()));
             }
 
-            let always_encode_mir: String = "always-encode-mir".into();
+            let always_encode_mir = "always-encode-mir";
             if !rustc_command_line_arguments
                 .iter()
-                .any(|arg| arg.ends_with(&always_encode_mir))
+                .any(|arg| arg.ends_with(always_encode_mir))
             {
                 // Tell compiler to emit MIR into crate for every function with a body.
-                rustc_command_line_arguments.push("-Z".into());
-                rustc_command_line_arguments.push(always_encode_mir);
+                rustc_command_line_arguments.push(format!("-Z{always_encode_mir}"));
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,12 +53,9 @@ fn main() {
         args.remove(1);
     }
 
-    let mut rustc_command_line_arguments: Vec<String> = args[1..].into();
+    let mut rustc_command_line_arguments = args;
     rustc_driver::install_ice_hook("ice ice ice baby", |_| ());
     let exit_code = rustc_driver::catch_with_exit_code(|| {
-        // Add back the binary name
-        rustc_command_line_arguments.insert(0, args[0].clone());
-
         let print: String = "--print=".into();
         if rustc_command_line_arguments
             .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,13 +34,13 @@ fn main() {
     // Get any options specified via the LOCKBUD_FLAGS environment variable
     let options = Options::parse_from_str(&std::env::var("LOCKBUD_FLAGS").unwrap_or_default())
         .unwrap_or_default();
-    debug!("LOCKBUD options from environment: {:?}", options);
+    debug!("LOCKBUD options from environment: {options:?}");
     let mut args = std::env::args_os()
         .enumerate()
         .map(|(i, arg)| {
             arg.into_string().unwrap_or_else(|arg| {
                 handler.early_fatal(
-                    format!("Argument {} is not valid Unicode: {:?}", i, arg).to_string(),
+                    format!("Argument {i} is not valid Unicode: {arg:?}")
                 )
             })
         })
@@ -87,10 +87,7 @@ fn main() {
         }
 
         let mut callbacks = callbacks::LockBudCallbacks::new(options);
-        debug!(
-            "rustc_command_line_arguments {:?}",
-            rustc_command_line_arguments
-        );
+        debug!("rustc_command_line_arguments {rustc_command_line_arguments:?}");
         let compiler =
             rustc_driver::RunCompiler::new(&rustc_command_line_arguments, &mut callbacks);
         compiler.run()


### PR DESCRIPTION
This PR also
* fixes some minor problems in `format!` and `rustc_command_line_arguments`
* ignores  clippy::option_env_unwrap lint
* updates usage help due to https://github.com/BurtonQin/lockbud/pull/64