### PR TITLE
Update github action to Rust nightly-2024-05-21

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ inputs:
   rust_version:
     required: false
     description: using rust-toolchain version
-    default: nightly-2023-04-11
+    default: nightly-2024-05-21
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - v*
 
 env:
-  RUST_VERSION: nightly-2023-04-11
+  RUST_VERSION: nightly-2024-05-21
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo vendor > .cargo/config
 
 COPY src /opt/lockbud/src
 
-ARG RUST_VERSION=nightly-2023-04-11
+ARG RUST_VERSION=nightly-2024-05-21
 
 RUN cd /opt/lockbud/ && \
     rustup default ${RUST_VERSION} && \
@@ -25,7 +25,7 @@ RUN cd /opt/lockbud/ && \
 
 FROM rust:slim
 
-ARG RUST_VERSION=nightly-2023-04-11
+ARG RUST_VERSION=nightly-2024-05-21
 
 RUN rustup default ${RUST_VERSION}
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-04-11"
+channel = "nightly-2024-05-21"
 components = [ "rust-src", "rustc-dev", "llvm-tools-preview" ]


### PR DESCRIPTION
Updates the Github action to run with Rust nightly-2024-05-21.

I haven't tested deploying and running the updated action yet