### PR TITLE
Latest Rust nightly support

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-05-21"
+channel = "nightly-2024-10-05"
 components = [ "rust-src", "rustc-dev", "llvm-tools-preview", "clippy" ]

--- a/src/analysis/defuse/mod.rs
+++ b/src/analysis/defuse/mod.rs
@@ -59,8 +59,8 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
         PlaceContext::NonMutatingUse(NonMutatingUseContext::FakeBorrow) |
         PlaceContext::NonMutatingUse(NonMutatingUseContext::PlaceMention)|
 
-        PlaceContext::MutatingUse(MutatingUseContext::AddressOf) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::AddressOf) |
+        PlaceContext::MutatingUse(MutatingUseContext::RawBorrow) |
+        PlaceContext::NonMutatingUse(NonMutatingUseContext::RawBorrow) |
         PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect) |
         PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) |
         PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) |

--- a/src/analysis/pointsto/mod.rs
+++ b/src/analysis/pointsto/mod.rs
@@ -495,7 +495,7 @@ impl<'a, 'tcx> ConstraintGraphCollector<'a, 'tcx> {
                 vec![Self::process_operand(operand)]
             }
             // Regard `p = &*q` as `p = q`
-            Rvalue::Ref(_, _, place) | Rvalue::AddressOf(_, place) => match place.as_ref() {
+            Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) => match place.as_ref() {
                 PlaceRef {
                     local: l,
                     projection: [ProjectionElem::Deref, ref remain @ ..],
@@ -594,8 +594,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ConstraintGraphCollector<'a, 'tcx> {
         } = &terminator.kind
         {
             match (
-                args.as_slice()
-                    .iter()
+                args.iter()
                     .map(|x| x.node.clone())
                     .collect::<Vec<_>>()
                     .as_slice(),

--- a/src/bin/cargo-lockbud.rs
+++ b/src/bin/cargo-lockbud.rs
@@ -24,7 +24,7 @@ Examples:
     # skip detecting [mycrate1, mycrate2]
     cargo lockbud -k deadlock -b -l mycrate1,mycrate2
     # canonical command with toolchain overridden and target triple specified
-    cargo +nightly-2024-05-21 lockbud -k all -- --target riscv64gc-unknown-none-elf
+    cargo +nightly-2024-10-05 lockbud -k all -- --target riscv64gc-unknown-none-elf
 "#;
 
 fn show_help() {

--- a/src/interest/concurrency/lock.rs
+++ b/src/interest/concurrency/lock.rs
@@ -280,7 +280,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for LockGuardCollector<'a, 'b, 'tcx> {
                             let term = self.body[location.block].terminator();
                             if let TerminatorKind::Call { ref func, .. } = term.kind {
                                 let func_ty = func.ty(self.body, self.tcx);
-                                // Only after monomorphizing can Instance::resolve work
+                                // Only after monomorphizing can Instance::try_resolve work
                                 let func_ty =
                                     self.instance.instantiate_mir_and_normalize_erasing_regions(
                                         self.tcx,


### PR DESCRIPTION
In an effort to keep up to date with the latest Rust nightly I've made some changes here to support 2024-10-05 Rust nightly. Test cases are all passing. I've ran this against Lighthouse (see here: https://github.com/eserilev/lighthouse/actions/runs/11209194102/job/31154037562?pr=9) using the changes in this PR and it seem to work. However, I am very unfamiliar with the inner workings of this codebase and am unsure if I have introduced any regressions. 

I have a docker image built here if that's helpful
https://hub.docker.com/r/eserilev/lockbud