### PR TITLE
Use repeatable build instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,8 @@ Currently supports rustc nightly-2024-12-01 (Thanks to @mokhaled2992).
 ```
 $ git clone https://github.com/BurtonQin/lockbud.git
 $ cd lockbud
-$ rustup component add rust-src
-$ rustup component add rustc-dev
-$ rustup component add llvm-tools-preview
-$ cargo install --path .
+$ rustup +nightly-2025-02-01 component add rust-src rustc-dev llvm-tools-preview
+$ cargo +nightly-2025-02-01 install --path .
 ```
 
 Note that you must use the same rustc nightly version as lockbud to detect your project!


### PR DESCRIPTION
Show how to specify the correct compiler version

refs: https://github.com/BurtonQin/lockbud/issues/82